### PR TITLE
Python bindings: use cmakemodules for the install process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,38 @@ Posture Generator
 Posture Generator (PG) is a library that computes the inverse kinematics of
 kinematic trees.
 
+
+## Dependencies
+
+* C++ compiler with C++11 support
+* Boost
+* CMake
+* Eigen 3
+* RBDyn
+* SpaceVecAlg
+* roboptim-core
+* sch-core
+
+For Python bindings:
+
+* Python 2 or 3
+* PyBindGen
+
+
+## Install
+
+```sh
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=[your install prefix]
+make
+make install
+```
+
+Note: the usual install prefix is `/usr`, but it defaults to `/usr/local`.
+
+If you generate Python bindings on Debian-based distributions (e.g. Ubuntu),
+you may want to choose the Debian layout for Python packages (e.g.
+`/usr/lib/python2.7/dist-packages/`) instead of the default one (e.g.
+`/usr/lib/python2.7/site-packages/`). If this is the case, add the
+`-DPYTHON_DEB_LAYOUT=ON` flag to the CMake command.
+

--- a/binding/python/CMakeLists.txt
+++ b/binding/python/CMakeLists.txt
@@ -1,5 +1,8 @@
-find_package(PythonInterp REQUIRED)
-find_package(PythonLibs REQUIRED)
+include(../../cmake/python.cmake)
+
+# Look for Python 2.7
+SET(Python_ADDITIONAL_VERSIONS 2.7)
+FINDPYTHON()
 
 # PG
 
@@ -20,7 +23,7 @@ add_custom_command (
 set(SOURCES ${OUTPUT_BINDING})
 include_directories(.)
 include_directories(../../src)
-include_directories(${PYTHON_INCLUDE_DIRS})
+include_directories(SYSTEM ${PYTHON_INCLUDE_DIRS})
 
 add_library(_pg SHARED ${SOURCES})
 target_link_libraries(_pg PG)
@@ -33,17 +36,6 @@ set_target_properties(_pg PROPERTIES PREFIX "")
 set_target_properties(_pg PROPERTIES INSTALL_RPATH
     "${CMAKE_INSTALL_RPATH};${ROBOPTIM_CORE_PLUGIN_IPOPT_LIBRARY_DIRS}")
 
-
 # install rules
-# find python version (not implemented in cmake 2.8.5)
-execute_process(COMMAND "${PYTHON_EXECUTABLE}" -V ERROR_VARIABLE _VERSION
-                OUTPUT_QUIET ERROR_STRIP_TRAILING_WHITESPACE)
-string(REPLACE "Python " "" PYTHON_VERSION_STRING "${_VERSION}")
-string(REGEX REPLACE "^([0-9]+)\\.[0-9]+\\.[0-9]+.*" "\\1"
-       PYTHON_VERSION_MAJOR "${PYTHON_VERSION_STRING}")
-string(REGEX REPLACE "^[0-9]+\\.([0-9])+\\.[0-9]+.*" "\\1"
-       PYTHON_VERSION_MINOR "${PYTHON_VERSION_STRING}")
-set(INSTALL_PATH
-  "lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/dist-packages/pg/")
-install(TARGETS _pg DESTINATION ${INSTALL_PATH})
-install(FILES __init__.py DESTINATION ${INSTALL_PATH})
+install(TARGETS _pg DESTINATION "${PYTHON_SITELIB}/pg")
+PYTHON_INSTALL_BUILD(pg __init__.py "${PYTHON_SITELIB}")


### PR DESCRIPTION
This solves the `site-packages`/`dist-packages` confusion, as was done in RBDyn. An explanation was added to `README.md`.
